### PR TITLE
Remove LF characters from result

### DIFF
--- a/base64Encode.bas
+++ b/base64Encode.bas
@@ -18,7 +18,7 @@ Function base64Encode(input as String) As String
         oNode.nodeTypedValue = Stream_StringToBinary(sText)
 
         'return
-        Base64Encode = oNode.Text
+        Base64Encode = Replace(oNode.Text, vbLf, "")
         
         'garbage collection
         Set oNode = Nothing


### PR DESCRIPTION
The MSXML library inserts LF characters every 72 characters for some obscure reasons. This will break Basic authentication for long username/password combinations.